### PR TITLE
Paket nightly untuk Centos/RHEL 7 dan Fedora 23/24/25/Rawhide

### DIFF
--- a/.tito/packages/.readme
+++ b/.tito/packages/.readme
@@ -1,0 +1,3 @@
+the .tito/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # KBBI Qt
 
 [![Build Status](https://travis-ci.org/bgli/kbbi-qt.svg?branch=master)](https://travis-ci.org/bgli/kbbi-qt)
+![Copr](https://copr.fedorainfracloud.org/coprs/alunux/kbbi-qt-git/package/KBBI-Qt/status_image/last_build.png)
 
 KBBI Qt adalah aplikasi Kamus Besar Bahasa Indonesia yang dikembangkan menggunakan bahasa pemrograman C++ dan Framework Qt.
 
 ![Screenshot](screenshot.png ""Screenshot"")
 
 # Ikut Terlibat
-Kami sangat terbuka apabila anda ingin bergabung dan terlibat dalam proyek ini. Segala bentuk kontribusi anda akan sangat membantu kami dalam mengembangkan aplikasi ini. 
+Kami sangat terbuka apabila anda ingin bergabung dan terlibat dalam proyek ini. Segala bentuk kontribusi anda akan sangat membantu kami dalam mengembangkan aplikasi ini.
 Kontribusi dapat berupa Bug Fix (code), Improvement (code), Dokumentasi, Publikasi, Pemaketan, dan lain sebagainya.
 
 # Diskusi

--- a/db_location.patch
+++ b/db_location.patch
@@ -1,0 +1,37 @@
+diff --git a/src/mainwindow.cpp b/src/mainwindow.cpp
+index e288912..ca03c38 100644
+--- a/src/mainwindow.cpp
++++ b/src/mainwindow.cpp
+@@ -20,7 +20,7 @@ MainWindow::MainWindow(QWidget *parent) :
+ 
+ 
+     // Init Database
+-    QString     mNamaDb = "KBBI.db";
++    QString     mNamaDb = "/opt/KBBI-Qt/KBBI.db";
+     QFileInfo   mFileDb(mNamaDb);
+ 
+     // qDebug()<< "Lokasi DB : " << mFileDb.absoluteFilePath();
+@@ -40,7 +40,7 @@ MainWindow::MainWindow(QWidget *parent) :
+ 
+     // Connect to DB
+     database = QSqlDatabase::addDatabase("QSQLITE");
+-    database.setDatabaseName("KBBI.db");
++    database.setDatabaseName("/opt/KBBI-Qt/KBBI.db");
+     database.open();
+ 
+     // qDebug()<< "Is connect? " << database.open();
+@@ -71,7 +71,7 @@ void MainWindow::copyDBfromRes(){
+     // Nama File output copy
+     // Tanpa full absolute path supaya diletakkan satu level
+     // di direktori yang sama dengan file aplikasi
+-    QString fileOut = "KBBI.db";
++    QString fileOut = "/opt/KBBI-Qt/KBBI.db";
+ 
+     // Copy File dari Resource File
+     if(QFile::copy(":/data/KBBI.db",fileOut)){
+@@ -149,5 +149,3 @@ MainWindow::~MainWindow()
+ {
+     delete ui;
+ }
+-
+-

--- a/kbbi-qt.spec
+++ b/kbbi-qt.spec
@@ -1,0 +1,102 @@
+%global _hardened_build 1
+%global debug_package %{nil}
+%define build_timestamp %(date +"%Y%m%d").git
+%define install_dir /opt/KBBI-Qt
+
+Summary: KBBI Qt: KBBI Qt adalah aplikasi Kamus Besar Bahasa Indonesia
+Name: KBBI-Qt
+Version: %{build_timestamp}
+Release: 1%{?dist}
+License: GPLv3
+Group: Applications/Productivity
+URL: https://github.com/bgli/kbbi-qt
+Source0: https://github.com/bgli/kbbi-qt/archive/master.zip
+BuildRequires: qt5-qtbase-devel ImageMagick
+Requires: qt5-qtbase
+
+%if 0%{?mga}
+BuildRequires: locales
+%endif
+
+%description
+KBBI Qt adalah aplikasi Kamus Besar Bahasa Indonesia yang dikembangkan
+menggunakan bahasa pemrograman C++ dan Framework Qt
+
+%prep
+%autosetup -n kbbi-qt-master
+patch -p1 < db_location.patch
+cd src
+for i in 256 128 64 48 32 24 16; do
+    mkdir -p icons/${i}
+    convert kbbi-qt.png -resize ${i}x${i} icons/${i}/kbbi-qt.png
+done
+
+%build
+cd src
+qmake-qt5
+make %{?_smp_mflags}
+
+%install
+cd src
+
+install -d %{buildroot}%{_bindir}
+install -d %{buildroot}%{install_dir}
+install -d %{buildroot}%{_datadir}/applications
+
+install -m 755 %{name} %{buildroot}%{install_dir}
+install -m 644 data/KBBI.db %{buildroot}%{install_dir}
+ln -sf %{install_dir}/%{name} %{buildroot}%{_bindir}
+
+cat >> %{name}.desktop << FOE
+[Desktop Entry]
+Version=0.1
+Name=KBBI Qt
+Comment=Aplikasi Kamus Besar Bahasa Indonesia
+Exec=%{name} %u
+Icon=%{name}
+Terminal=false
+Type=Application
+Categories=Utility;
+FOE
+
+install -m 644 %{name}.desktop \
+        %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+for i in 128 64 48 32 24 16; do
+    install -D -m 0644 icons/${i}/kbbi-qt.png \
+            %{buildroot}%{_datadir}/icons/hicolor/${i}x${i}/apps/%{name}.png
+done
+
+%post
+/bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null ||:
+/usr/bin/update-desktop-database &>/dev/null ||:
+/usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+
+%postun
+if [ $1 -eq 0 ]; then
+    /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null ||:
+    /usr/bin/gtk-update-icon-cache -f -t -q %{_datadir}/icons/hicolor ||:
+fi
+/usr/bin/update-desktop-database &>/dev/null ||:
+
+%posttrans
+/usr/bin/gtk-update-icon-cache -f -t -q %{_datadir}/icons/hicolor ||:
+
+%clean
+rm -rf %{buildroot} %{_builddir}/kbbi-qt-master
+
+%files
+%defattr(-,root,root,-)
+%doc README.md LICENSE
+%license LICENSE
+%{_bindir}/%{name}
+%dir %{install_dir}
+%{install_dir}/*
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/icons/hicolor/*/apps/%{name}.png
+
+%changelog
+* Mon Oct 31 2016 La Ode Muh. Fadlun Akbar <fadlun.net@gmail.com> - 20161031.git
+- Create RPM SPEC for kbbi-qt
+- Patch KBBI-Qt db location
+- Other changelog at https://github.com/bgli/kbbi-qt/commits/master


### PR DESCRIPTION
Letak berkas **.spec** dan **.patch** harus berada di topdir. Hal ini dikarenakan keterbatasan Copr dalam menghandle patch (tidak dapat menggunakan macros `Patch0:` dan `patch0`) ketika build dilakukan secara otomatis menggunakan tito. Jika ingin melakukan build di lokal, juga tetap bisa dengan menggunakan berkas **.spec** tersebut.

**Link Copr: https://copr.fedorainfracloud.org/coprs/alunux/kbbi-qt-git/**

**Cara penggunaan:** #4 

**[Centos/RHEL 7]**  

``` sh
$ sudo wget https://copr.fedorainfracloud.org/coprs/alunux/kbbi-qt-git/repo/epel-7/alunux-kbbi-qt-git-epel-7.repo -O /etc/yum.repos.d/kbbi-qt.repo
$ sudo yum install KBBI-Qt
```

**[Fedora 23/24/25/Rawhide]**  

``` sh
$ sudo dnf copr enable alunux/kbbi-qt-git
$ sudo dnf install KBBI-Qt
```

**Tested on Fedora 24**
![cobalagi-2016-10-31_06](https://cloud.githubusercontent.com/assets/10938708/19840912/d490e360-9f33-11e6-9ff0-501609822bb2.gif)
